### PR TITLE
Support new OAUth server-to-server flow

### DIFF
--- a/cmd/authz.go
+++ b/cmd/authz.go
@@ -29,6 +29,7 @@ This command has no effect by itself, the authorization type needs to be specifi
 		authzUserCmd(imsConfig),
 		authzServiceCmd(imsConfig),
 		authzJWTCmd(imsConfig),
+		authzOAuthCmd(imsConfig),
 	)
 	return cmd
 }

--- a/cmd/authz_oauth.go
+++ b/cmd/authz_oauth.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/adobe/imscli/ims"
+	"github.com/spf13/cobra"
+)
+
+func authzOAuthCmd(imsConfig *ims.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "oauth",
+		Short: "Negotiate authorization using OAuth Server-to-Server.",
+		Long:  "Perform the 'Client Credential Authorization Flow' to negotiate an access token for a service.'",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			resp, err := imsConfig.AuthorizeOAuth()
+			if err != nil {
+				return fmt.Errorf("error in login service: %v", err)
+			}
+			fmt.Println(resp)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&imsConfig.ClientID, "clientID", "c", "", "IMS client ID.")
+	cmd.Flags().StringVarP(&imsConfig.ClientSecret, "clientSecret", "p", "", "IMS client secret.")
+	cmd.Flags().StringSliceVarP(&imsConfig.Scopes, "scopes", "s", []string{""}, "Scopes to request.")
+
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ module github.com/adobe/imscli
 
 go 1.15
 
+replace github.com/adobe/ims-go => ../ims-go
+
 require (
 	github.com/adobe/ims-go v0.11.0
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4

--- a/ims/authz_oauth.go
+++ b/ims/authz_oauth.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package ims
+
+import (
+	"fmt"
+
+	"github.com/adobe/ims-go/ims"
+)
+
+/*
+ * AuthorizeOAuth : Login for the OAuth server to server IMS flow
+ */
+func (i Config) AuthorizeOAuth() (string, error) {
+
+	httpClient, err := i.httpClient()
+	if err != nil {
+		return "", fmt.Errorf("error creating the HTTP Client: %v", err)
+	}
+
+	c, err := ims.NewClient(&ims.ClientConfig{
+		URL:    i.URL,
+		Client: httpClient,
+	})
+	if err != nil {
+		return "", fmt.Errorf("create client: %v", err)
+	}
+
+	r, err := c.Token(&ims.TokenRequest{
+		ClientID:     i.ClientID,
+		ClientSecret: i.ClientSecret,
+		Scope:        i.Scopes,
+		GrantType:    "client_credentials",
+	})
+	if err != nil {
+		return "", fmt.Errorf("request token: %v", err)
+	}
+
+	return r.AccessToken, nil
+}


### PR DESCRIPTION
## Description

IMS Authentication will switch from JWT to OAuth server-to-server authentication.
This change will add support for the new client_credentials call to /ims/token endpoint
Reference: https://developer.adobe.com/developer-console/docs/guides/authentication/ServerToServerAuthentication/migration/

## Related Issue

N/A

## Motivation and Context

Support for new authentication mechanism to allow migration to new concept.

## How Has This Been Tested?

- Tested locally towards IMS STAGE using existing credentials

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
