### PR TITLE
Use `go install` in module-aware mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,9 @@ This project is wrapping adobe/ims-go.
 Build the CLI or download a prebuilt [release](https://github.com/adobe/imscli/releases).
 
 Example:
-```
-git clone https://github.com/adobe/imscli
 
-go install
+```sh
+go install github.com/adobe/imscli@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Since Go 1.16, `go install` can run in module-aware mode, which is activated if the argument is suffixed by an `@` and a version. This PR updates the README by using `go install` in module-aware mode.
