### PR TITLE
Upgrade deprecated items in goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 project_name: imscli
 before:
   hooks:
@@ -16,11 +17,11 @@ builds:
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
+        formats: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Version }}-next"
+  version_template: "{{ .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
After updating the github gorelease action, some options used were deprecated.

Update the config file to adopt the modern goreleaser 2.x options.